### PR TITLE
Implement multiple timeframes per strategy feature - Create strategy_…

### DIFF
--- a/app/Models/Timeframe.php
+++ b/app/Models/Timeframe.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Timeframe extends Model
 {
@@ -19,11 +19,13 @@ class Timeframe extends Model
     ];
 
     /**
-     * Get the strategies for the timeframe.
+     * Get the strategies that use this timeframe (many-to-many).
      */
-    public function strategies(): HasMany
+    public function strategies(): BelongsToMany
     {
-        return $this->hasMany(Strategy::class);
+        return $this->belongsToMany(Strategy::class, 'strategy_timeframes')
+                    ->withPivot('is_primary')
+                    ->withTimestamps();
     }
 
     /**

--- a/database/migrations/2025_06_02_204330_create_strategy_timeframes_table.php
+++ b/database/migrations/2025_06_02_204330_create_strategy_timeframes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('strategy_timeframes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('strategy_id')->constrained()->onDelete('cascade');
+            $table->foreignId('timeframe_id')->constrained()->onDelete('cascade');
+            $table->boolean('is_primary')->default(false); // Mark one timeframe as primary for display
+            $table->timestamps();
+            
+            // Ensure unique combination of strategy and timeframe
+            $table->unique(['strategy_id', 'timeframe_id']);
+            
+            // Add indexes for performance
+            $table->index('strategy_id');
+            $table->index('timeframe_id');
+            $table->index(['strategy_id', 'is_primary']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('strategy_timeframes');
+    }
+};

--- a/database/migrations/2025_06_02_204345_migrate_timeframe_data_to_pivot_table.php
+++ b/database/migrations/2025_06_02_204345_migrate_timeframe_data_to_pivot_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Migrate existing timeframe_id data to the pivot table
+        $strategies = DB::table('strategies')->whereNotNull('timeframe_id')->get();
+        
+        foreach ($strategies as $strategy) {
+            DB::table('strategy_timeframes')->insert([
+                'strategy_id' => $strategy->id,
+                'timeframe_id' => $strategy->timeframe_id,
+                'is_primary' => true, // Mark the existing timeframe as primary
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Remove all data from pivot table (this will be recreated if we rollback)
+        DB::table('strategy_timeframes')->truncate();
+    }
+};

--- a/database/migrations/2025_06_02_204404_remove_timeframe_id_from_strategies_table.php
+++ b/database/migrations/2025_06_02_204404_remove_timeframe_id_from_strategies_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('strategies', function (Blueprint $table) {
+            // Drop foreign key constraint first
+            $table->dropForeign(['timeframe_id']);
+            // Then drop the column
+            $table->dropColumn('timeframe_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('strategies', function (Blueprint $table) {
+            // Recreate the column and foreign key if rolling back
+            $table->foreignId('timeframe_id')->nullable()->constrained()->onDelete('restrict');
+        });
+    }
+};

--- a/resources/views/strategies/create.blade.php
+++ b/resources/views/strategies/create.blade.php
@@ -35,22 +35,55 @@
                             @enderror
                         </div>
 
-                        <!-- Timeframe -->
+                        <!-- Timeframes -->
                         <div class="mb-4">
-                            <label for="timeframe_id" class="block text-sm font-medium text-gray-300">Timeframe *</label>
-                            <select name="timeframe_id" id="timeframe_id" 
-                                    class="mt-1 block w-full rounded-md bg-gray-900 border-gray-600 text-white shadow-sm focus:border-gray-500 focus:ring-gray-500 @error('timeframe_id') border-red-500 @enderror" 
-                                    required>
-                                <option value="">Select a timeframe</option>
+                            <label for="timeframe_ids" class="block text-sm font-medium text-gray-300">Timeframes *</label>
+                            <div class="mt-1 space-y-2">
+                                <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+                                    @foreach($timeframes as $timeframe)
+                                        <label class="flex items-center space-x-2 p-2 border border-gray-600 rounded-md hover:bg-gray-700 cursor-pointer">
+                                            <input type="checkbox" 
+                                                   name="timeframe_ids[]" 
+                                                   value="{{ $timeframe->id }}"
+                                                   {{ collect(old('timeframe_ids'))->contains($timeframe->id) ? 'checked' : '' }}
+                                                   class="h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-600 rounded bg-gray-900"
+                                                   onchange="updatePrimaryTimeframeOptions()">
+                                            <span class="text-sm text-white font-medium">{{ $timeframe->name }}</span>
+                                            @if($timeframe->description)
+                                                <span class="text-xs text-gray-400">- {{ $timeframe->description }}</span>
+                                            @endif
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                            @error('timeframe_ids')
+                                <p class="mt-1 text-sm text-red-400">{{ $message }}</p>
+                            @enderror
+                            <p class="mt-1 text-xs text-gray-400">Select all timeframes this strategy will use</p>
+                        </div>
+
+                        <!-- Primary Timeframe -->
+                        <div class="mb-4">
+                            <label for="primary_timeframe_id" class="block text-sm font-medium text-gray-300">Primary Timeframe *</label>
+                            <select name="primary_timeframe_id" id="primary_timeframe_id" required
+                                    class="mt-1 block w-full rounded-md bg-gray-900 border-gray-600 text-white shadow-sm focus:border-gray-500 focus:ring-gray-500 @error('primary_timeframe_id') border-red-500 @enderror">
+                                <option value="">Select primary timeframe...</option>
                                 @foreach($timeframes as $timeframe)
-                                    <option value="{{ $timeframe->id }}" {{ old('timeframe_id') == $timeframe->id ? 'selected' : '' }}>
-                                        {{ $timeframe->name }} - {{ $timeframe->description }}
+                                    <option value="{{ $timeframe->id }}" 
+                                            {{ old('primary_timeframe_id') == $timeframe->id ? 'selected' : '' }}
+                                            data-timeframe-id="{{ $timeframe->id }}"
+                                            style="display: none;">
+                                        {{ $timeframe->name }}
+                                        @if($timeframe->description)
+                                            - {{ $timeframe->description }}
+                                        @endif
                                     </option>
                                 @endforeach
                             </select>
-                            @error('timeframe_id')
+                            @error('primary_timeframe_id')
                                 <p class="mt-1 text-sm text-red-400">{{ $message }}</p>
                             @enderror
+                            <p class="mt-1 text-xs text-gray-400">Choose the main timeframe for strategy decisions</p>
                         </div>
 
                         <!-- Group -->
@@ -127,4 +160,45 @@
             </div>
         </div>
     </div>
+
+    <script>
+        function updatePrimaryTimeframeOptions() {
+            const checkboxes = document.querySelectorAll('input[name="timeframe_ids[]"]');
+            const primarySelect = document.getElementById('primary_timeframe_id');
+            const selectedTimeframes = [];
+            
+            // Get all checked timeframes
+            checkboxes.forEach(checkbox => {
+                if (checkbox.checked) {
+                    selectedTimeframes.push(checkbox.value);
+                }
+            });
+            
+            // Show/hide options in primary timeframe select
+            const options = primarySelect.querySelectorAll('option[data-timeframe-id]');
+            options.forEach(option => {
+                const timeframeId = option.getAttribute('data-timeframe-id');
+                if (selectedTimeframes.includes(timeframeId)) {
+                    option.style.display = '';
+                } else {
+                    option.style.display = 'none';
+                    // Clear selection if this option was selected but is no longer available
+                    if (option.selected) {
+                        option.selected = false;
+                        primarySelect.value = '';
+                    }
+                }
+            });
+            
+            // If only one timeframe is selected, auto-select it as primary
+            if (selectedTimeframes.length === 1) {
+                primarySelect.value = selectedTimeframes[0];
+            }
+        }
+        
+        // Initialize on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            updatePrimaryTimeframeOptions();
+        });
+    </script>
 </x-app-layout> 

--- a/resources/views/strategies/edit.blade.php
+++ b/resources/views/strategies/edit.blade.php
@@ -48,14 +48,50 @@
                             <p class="mt-1 text-xs text-gray-400">Enter symbols separated by commas. Examples: <strong>Forex:</strong> EURUSD, GBPJPY, XAUUSD • <strong>Stocks:</strong> AAPL, TSLA, SPY • <strong>Futures:</strong> ES, NQ, CL, GC</p>
                         </div>
 
-                        <!-- Timeframe -->
+                        <!-- Timeframes -->
                         <div class="mb-4">
-                            <label for="timeframe_id" class="block text-sm font-medium text-gray-300">Timeframe *</label>
-                            <select name="timeframe_id" id="timeframe_id" required
-                                    class="mt-1 block w-full rounded-md bg-gray-900 border-gray-600 text-white shadow-sm focus:border-gray-500 focus:ring-gray-500 @error('timeframe_id') border-red-500 @enderror">
-                                <option value="">Select timeframe...</option>
+                            <label for="timeframe_ids" class="block text-sm font-medium text-gray-300">Timeframes *</label>
+                            <div class="mt-1 space-y-2">
+                                <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+                                    @foreach($timeframes as $timeframe)
+                                        @php
+                                            $isSelected = $strategy->timeframes->contains('id', $timeframe->id) || collect(old('timeframe_ids'))->contains($timeframe->id);
+                                        @endphp
+                                        <label class="flex items-center space-x-2 p-2 border border-gray-600 rounded-md hover:bg-gray-700 cursor-pointer">
+                                            <input type="checkbox" 
+                                                   name="timeframe_ids[]" 
+                                                   value="{{ $timeframe->id }}"
+                                                   {{ $isSelected ? 'checked' : '' }}
+                                                   class="h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-600 rounded bg-gray-900"
+                                                   onchange="updatePrimaryTimeframeOptions()">
+                                            <span class="text-sm text-white font-medium">{{ $timeframe->name }}</span>
+                                            @if($timeframe->description)
+                                                <span class="text-xs text-gray-400">- {{ $timeframe->description }}</span>
+                                            @endif
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                            @error('timeframe_ids')
+                                <p class="mt-1 text-sm text-red-400">{{ $message }}</p>
+                            @enderror
+                            <p class="mt-1 text-xs text-gray-400">Select all timeframes this strategy will use</p>
+                        </div>
+
+                        <!-- Primary Timeframe -->
+                        <div class="mb-4">
+                            <label for="primary_timeframe_id" class="block text-sm font-medium text-gray-300">Primary Timeframe *</label>
+                            <select name="primary_timeframe_id" id="primary_timeframe_id" required
+                                    class="mt-1 block w-full rounded-md bg-gray-900 border-gray-600 text-white shadow-sm focus:border-gray-500 focus:ring-gray-500 @error('primary_timeframe_id') border-red-500 @enderror">
+                                <option value="">Select primary timeframe...</option>
                                 @foreach($timeframes as $timeframe)
-                                    <option value="{{ $timeframe->id }}" {{ old('timeframe_id', $strategy->timeframe_id) == $timeframe->id ? 'selected' : '' }}>
+                                    @php
+                                        $isPrimary = $strategy->timeframes->where('pivot.is_primary', true)->first()?->id == $timeframe->id;
+                                        $isSelected = old('primary_timeframe_id') == $timeframe->id || ($isPrimary && !old('primary_timeframe_id'));
+                                    @endphp
+                                    <option value="{{ $timeframe->id }}" 
+                                            {{ $isSelected ? 'selected' : '' }}
+                                            data-timeframe-id="{{ $timeframe->id }}">
                                         {{ $timeframe->name }}
                                         @if($timeframe->description)
                                             - {{ $timeframe->description }}
@@ -63,9 +99,10 @@
                                     </option>
                                 @endforeach
                             </select>
-                            @error('timeframe_id')
+                            @error('primary_timeframe_id')
                                 <p class="mt-1 text-sm text-red-400">{{ $message }}</p>
                             @enderror
+                            <p class="mt-1 text-xs text-gray-400">Choose the main timeframe for strategy decisions</p>
                         </div>
 
                         <!-- Group -->
@@ -147,4 +184,45 @@
             </div>
         </div>
     </div>
+
+    <script>
+        function updatePrimaryTimeframeOptions() {
+            const checkboxes = document.querySelectorAll('input[name="timeframe_ids[]"]');
+            const primarySelect = document.getElementById('primary_timeframe_id');
+            const selectedTimeframes = [];
+            
+            // Get all checked timeframes
+            checkboxes.forEach(checkbox => {
+                if (checkbox.checked) {
+                    selectedTimeframes.push(checkbox.value);
+                }
+            });
+            
+            // Show/hide options in primary timeframe select
+            const options = primarySelect.querySelectorAll('option[data-timeframe-id]');
+            options.forEach(option => {
+                const timeframeId = option.getAttribute('data-timeframe-id');
+                if (selectedTimeframes.includes(timeframeId)) {
+                    option.style.display = '';
+                } else {
+                    option.style.display = 'none';
+                    // Clear selection if this option was selected but is no longer available
+                    if (option.selected) {
+                        option.selected = false;
+                        primarySelect.value = '';
+                    }
+                }
+            });
+            
+            // If only one timeframe is selected, auto-select it as primary
+            if (selectedTimeframes.length === 1) {
+                primarySelect.value = selectedTimeframes[0];
+            }
+        }
+        
+        // Initialize on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            updatePrimaryTimeframeOptions();
+        });
+    </script>
 </x-app-layout> 

--- a/resources/views/strategies/index.blade.php
+++ b/resources/views/strategies/index.blade.php
@@ -31,7 +31,18 @@
                                             </a>
                                         </h3>
                                         <div class="mt-1 flex items-center space-x-4 text-sm text-gray-400">
-                                            <span>{{ $strategy->timeframe->name }}</span>
+                                            <span class="flex items-center space-x-1">
+                                                @if($strategy->timeframes->count() > 0)
+                                                    @foreach($strategy->timeframes->sortBy('sort_order') as $timeframe)
+                                                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium 
+                                                            {{ $timeframe->pivot->is_primary ? 'bg-blue-800 text-blue-200' : 'bg-gray-700 text-gray-300' }}">
+                                                            {{ $timeframe->name }}
+                                                        </span>
+                                                    @endforeach
+                                                @else
+                                                    <span class="text-gray-500">No timeframes</span>
+                                                @endif
+                                            </span>
                                             @if($strategy->symbols_traded)
                                                 <span>•</span>
                                                 <span>{{ $strategy->symbols_traded }}</span>

--- a/resources/views/strategies/show.blade.php
+++ b/resources/views/strategies/show.blade.php
@@ -56,13 +56,29 @@
                             </div>
                         </div>
 
-                        <!-- Timeframe -->
+                        <!-- Timeframes -->
                         <div>
-                            <label class="block text-sm font-medium text-gray-300 mb-2">Timeframe</label>
-                            <div class="text-sm text-white bg-gray-900 px-3 py-2 rounded-md border border-gray-600">
-                                {{ $strategy->timeframe->name }}
-                                @if($strategy->timeframe->description)
-                                    <span class="text-gray-400">({{ $strategy->timeframe->description }})</span>
+                            <label class="block text-sm font-medium text-gray-300 mb-2">Timeframes</label>
+                            <div class="text-sm bg-gray-900 px-3 py-2 rounded-md border border-gray-600">
+                                @if($strategy->timeframes->count() > 0)
+                                    <div class="flex flex-wrap gap-2">
+                                        @foreach($strategy->timeframes->sortBy('sort_order') as $timeframe)
+                                            <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium 
+                                                {{ $timeframe->pivot->is_primary ? 'bg-blue-900 text-blue-200 border border-blue-600' : 'bg-gray-700 text-gray-300 border border-gray-600' }}">
+                                                {{ $timeframe->name }}
+                                                @if($timeframe->pivot->is_primary)
+                                                    <span class="ml-1 text-blue-300">•</span>
+                                                @endif
+                                            </span>
+                                        @endforeach
+                                    </div>
+                                    @if($strategy->timeframes->where('pivot.is_primary', true)->first())
+                                        <p class="text-xs text-gray-400 mt-1">
+                                            Primary: {{ $strategy->timeframes->where('pivot.is_primary', true)->first()->name }}
+                                        </p>
+                                    @endif
+                                @else
+                                    <span class="text-gray-400">No timeframes assigned</span>
                                 @endif
                             </div>
                         </div>


### PR DESCRIPTION
…timeframes pivot table with is_primary flag - Migrate existing timeframe_id data to pivot table - Remove old timeframe_id column from strategies table - Update Strategy/Timeframe models with many-to-many relationships - Update StrategyController for timeframe_ids array validation - Create/Edit forms: Multi-select timeframes with primary selection - Show/Index views: Display multiple timeframes with primary highlighted - Add JavaScript for dynamic primary timeframe options - Backward compatible data migration with professional UI