### PR TITLE
feat(api): Implement Symbols REST API

### DIFF
--- a/app/Http/Controllers/Api/V1/SymbolController.php
+++ b/app/Http/Controllers/Api/V1/SymbolController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Symbol;
+use App\Http\Resources\SymbolResource;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * @OA\Tag(
+ *     name="Symbols",
+ *     description="API Endpoints for Managing Trading Symbols"
+ * )
+ */
+class SymbolController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/api/v1/symbols",
+     *     summary="Get a list of symbols",
+     *     tags={"Symbols"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(name="per_page", in="query", required=false, @OA\Schema(type="integer", default=15)),
+     *     @OA\Response(response=200, description="A paginated list of symbols", @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/SymbolResource")))
+     * )
+     */
+    public function index(Request $request)
+    {
+        $perPage = $request->query('per_page', 15);
+        $symbols = Symbol::paginate($perPage);
+        return SymbolResource::collection($symbols);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/v1/symbols",
+     *     summary="Create a new symbol",
+     *     tags={"Symbols"},
+     *     security={{"sanctum":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"code", "symbol"},
+     *             @OA\Property(property="code", type="string", example="EURUSD"),
+     *             @OA\Property(property="symbol", type="string", example="Euro / US Dollar")
+     *         )
+     *     ),
+     *     @OA\Response(response=201, description="Symbol created successfully", @OA\JsonContent(ref="#/components/schemas/SymbolResource")),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'code' => 'required|string|unique:symbols,code|max:255',
+            'symbol' => 'required|string|max:255',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $symbol = Symbol::create($validator->validated());
+
+        return (new SymbolResource($symbol))
+                ->response()
+                ->setStatusCode(201);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/v1/symbols/{id}",
+     *     summary="Get a specific symbol",
+     *     tags={"Symbols"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Symbol details", @OA\JsonContent(ref="#/components/schemas/SymbolResource")),
+     *     @OA\Response(response=404, description="Symbol not found")
+     * )
+     */
+    public function show(Symbol $symbol)
+    {
+        return new SymbolResource($symbol);
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/api/v1/symbols/{id}",
+     *     summary="Update a symbol",
+     *     tags={"Symbols"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"code", "symbol"},
+     *             @OA\Property(property="code", type="string"),
+     *             @OA\Property(property="symbol", type="string")
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Symbol updated successfully", @OA\JsonContent(ref="#/components/schemas/SymbolResource")),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=404, description="Symbol not found")
+     * )
+     */
+    public function update(Request $request, Symbol $symbol)
+    {
+        $validator = Validator::make($request->all(), [
+            'code' => 'required|string|unique:symbols,code,' . $symbol->id . '|max:255',
+            'symbol' => 'required|string|max:255',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $symbol->update($validator->validated());
+
+        return new SymbolResource($symbol);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/v1/symbols/{id}",
+     *     summary="Delete a symbol",
+     *     tags={"Symbols"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=204, description="Symbol deleted successfully"),
+     *     @OA\Response(response=404, description="Symbol not found")
+     * )
+     */
+    public function destroy(Symbol $symbol)
+    {
+        $symbol->delete();
+
+        return response()->noContent();
+    }
+} 

--- a/app/Http/Middleware/CheckIfAdmin.php
+++ b/app/Http/Middleware/CheckIfAdmin.php
@@ -15,7 +15,7 @@ class CheckIfAdmin
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (!$request->user() || !$request->user()->is_admin) {
+        if (!$request->user() || !$request->user()->isAdmin()) {
             abort(403, 'Access to API documentation is restricted to administrators.');
         }
 

--- a/app/Http/Resources/SymbolResource.php
+++ b/app/Http/Resources/SymbolResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @OA\Schema(
+ *     schema="SymbolResource",
+ *     title="Symbol Resource",
+ *     description="A trading symbol",
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="code", type="string", example="EURUSD"),
+ *     @OA\Property(property="symbol", type="string", example="Euro / US Dollar"),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ */
+class SymbolResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'code' => $this->code,
+            'symbol' => $this->symbol,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+} 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -142,4 +142,12 @@ class User extends Authenticatable
     {
         return $this->hasMany(StatusHistory::class, 'changed_by_user_id');
     }
+
+    /**
+     * Check if the user is an administrator.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->groups()->where('name', 'Administrators')->exists();
+    }
 }

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -66,15 +66,15 @@ return [
              */
             'middleware' => [
                 'api' => [
-                    'auth:sanctum',
+                    'web',
                     \App\Http\Middleware\CheckIfAdmin::class,
                 ],
                 'asset' => [
-                    'auth:sanctum',
+                    'web',
                     \App\Http\Middleware\CheckIfAdmin::class,
                 ],
                 'docs' => [
-                    'auth:sanctum',
+                    'web',
                     \App\Http\Middleware\CheckIfAdmin::class,
                 ],
                 'oauth2_callback' => [],

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\StrategyController;
 use App\Http\Controllers\Api\V1\PortfolioController;
+use App\Http\Controllers\Api\V1\SymbolController;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
@@ -17,4 +18,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->name('api.v1.')->group(function
 
     // Portfolio Routes
     Route::apiResource('portfolios', PortfolioController::class);
+    
+    // Symbol Routes
+    Route::apiResource('symbols', SymbolController::class);
 }); 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -520,9 +520,260 @@
                     }
                 ]
             }
+        },
+        "/api/v1/symbols": {
+            "get": {
+                "tags": [
+                    "Symbols"
+                ],
+                "summary": "Get a list of symbols",
+                "operationId": "7412fd3a8ff6f1cd4a055a7dbfb6147a",
+                "parameters": [
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 15
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A paginated list of symbols",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SymbolResource"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Symbols"
+                ],
+                "summary": "Create a new symbol",
+                "operationId": "6d300208a2d500e38a26125762bbbde0",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "code",
+                                    "symbol"
+                                ],
+                                "properties": {
+                                    "code": {
+                                        "type": "string",
+                                        "example": "EURUSD"
+                                    },
+                                    "symbol": {
+                                        "type": "string",
+                                        "example": "Euro / US Dollar"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Symbol created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SymbolResource"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/symbols/{id}": {
+            "get": {
+                "tags": [
+                    "Symbols"
+                ],
+                "summary": "Get a specific symbol",
+                "operationId": "8f941bd6a0a582581e8023ab0f43e219",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Symbol details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SymbolResource"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Symbol not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Symbols"
+                ],
+                "summary": "Update a symbol",
+                "operationId": "1284e6f767b12cf286ba0dbd82ea6fe0",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "code",
+                                    "symbol"
+                                ],
+                                "properties": {
+                                    "code": {
+                                        "type": "string"
+                                    },
+                                    "symbol": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Symbol updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SymbolResource"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    },
+                    "404": {
+                        "description": "Symbol not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Symbols"
+                ],
+                "summary": "Delete a symbol",
+                "operationId": "d6b2faac54e88440259969f381622889",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Symbol deleted successfully"
+                    },
+                    "404": {
+                        "description": "Symbol not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
         }
     },
     "components": {
+        "schemas": {
+            "SymbolResource": {
+                "title": "Symbol Resource",
+                "description": "A trading symbol",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "code": {
+                        "type": "string",
+                        "example": "EURUSD"
+                    },
+                    "symbol": {
+                        "type": "string",
+                        "example": "Euro / US Dollar"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            }
+        },
         "securitySchemes": {
             "sanctum": {
                 "type": "http",
@@ -538,6 +789,10 @@
         {
             "name": "Strategies",
             "description": "API Endpoints for Managing Strategies"
+        },
+        {
+            "name": "Symbols",
+            "description": "API Endpoints for Managing Trading Symbols"
         }
     ]
 }


### PR DESCRIPTION
This PR adds a full REST API for managing trading symbols. It includes the controller, resource, routes, and OpenAPI documentation. It also contains important fixes for the API documentation generation and the admin authorization middleware.