### PR TITLE
Bugfix: Idempotent and robust SymbolSeeder prevents duplicate entry errors and halts on SQL issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,3 +524,5 @@ The GitHub Actions workflow now automatically installs Node.js dependencies and 
   - If you see a 500 error after deployment, check that the `vendor` directory exists and is complete on the server.
   - You can always re-trigger the GitHub Actions deploy workflow to rebuild and redeploy all dependencies.
 - For more details, see `.github/workflows/deploy.yml` and the comments in the workflow file.
+
+- The SymbolSeeder is now robust and idempotent: it uses updateOrCreate to avoid duplicate entry errors, and will halt deployment with a clear error message if any SQL/database problem occurs during seeding. This ensures no silent failures or duplicate entry errors during production deploys.

--- a/database/seeders/SymbolSeeder.php
+++ b/database/seeders/SymbolSeeder.php
@@ -5,6 +5,8 @@ namespace Database\Seeders;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use App\Models\Symbol;
+use Illuminate\Support\Facades\Log;
 
 class SymbolSeeder extends Seeder
 {
@@ -18,14 +20,22 @@ class SymbolSeeder extends Seeder
         // Skip the first line (header)
         fgetcsv($csvFile);
         
-        // Read and insert each line
-        while (($data = fgetcsv($csvFile)) !== false) {
-            DB::table('symbols')->insert([
-                'code' => $data[0],
-                'symbol' => $data[1],
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
+        try {
+            // Read and insert each line
+            while (($data = fgetcsv($csvFile)) !== false) {
+                Symbol::updateOrCreate(
+                    ['code' => $data[0]],
+                    [
+                        'symbol' => $data[1],
+                        'updated_at' => now(),
+                    ]
+                );
+            }
+        } catch (\Exception $e) {
+            Log::error('SymbolSeeder SQL error: ' . $e->getMessage());
+            echo "\n[SymbolSeeder] SQL error: " . $e->getMessage() . "\n";
+            fclose($csvFile);
+            exit(1); // Stop the seeder and fail the deploy
         }
 
         fclose($csvFile);


### PR DESCRIPTION
## Summary\n\nThis PR makes the  robust and idempotent for all environments, especially production. It uses  to avoid duplicate entry errors and wraps the seeding logic in a try/catch block. If any SQL/database error occurs, it logs the error, outputs a clear message, and halts the deployment.\n\n## Details\n- Uses Eloquent's  to ensure no duplicate key errors, even if the seeder is run multiple times.\n- Catches and logs any SQL/database errors, outputs a clear message, and exits with a non-zero code to halt the deploy.\n- Guarantees that no silent failures or duplicate entry errors will occur during seeding in production.\n- README updated to document this guarantee and the improved deployment reliability.\n\n## Why?\n- Prevents 500 errors and failed deployments due to duplicate entries in the You must specify at least one file, pid, or task.

symbols  [-help]
         [-arch (all | any | $arch_name)]
         [-cpuType #] [-cpuSubtype #]
         [-originalBinary path]...
         [-saveSignature path]
         [-symbolsPackageDir path]
         [-lookup (0x1234 | "symname")...] symname may use wildcards
         [-cacheMemoryLimit #]
         [-iterations #]
         files... file-signatures... signatures... pids... tasks...

If no arch is specified, symbols defaults to the current architecture.
The search order is file, file-signature, signature, pid, task.
A file-signature is a file name ending in ".signature" and containing a
single ascii signature.

	-help               print this message
	-uuid               print uuids
	-noHeaders          do not print the headers
	-noRegions          do not print the regions
	-noSymbols          do not print the symbols
	-noSources          do not print source line info
	-noDemangling       do not print symbol names readably
	-printDemangling    print interesting mangled --> demangled symbol names
	-lazy               allow symbolicators to be lazy
	-printSignature     print each symbolicator's signature
	-deepSignature      created signatures will be "deep"
	-fullSourcePath     print source line info with full path
	-w                  force output to wide format
	-v                  print version info
	-arch               set the preferred architecture symbolically
	-cpuType            set the preferred architecture cpu type
	-cpuSubtype         set the preferred architecture cpu subtype
	-lookup             a list of addrs or symbols to lookup in each target
	-printCache         print cache data at exit
	-asyncCacheCleanup  cache cleans on a separate thread
	-syncCacheCleanup   cache cleans on deallocating thread
	-cacheMemoryLimit   set the cache memory limit (in MB)
	-iterations         iterate # times for each file, pid, or task
	-trackDyld          track dyld load/unload activity in target
	-hangOnDyldLoad     hang when receiving dyld load notice
	-hangOnDyldUnload   hang when receiving dyld unload notice
	-waitUntilExit      wait for target task exit notification
	-noNotifications    do not print notifications for each target
	-printNotifications print notifications for each target
	-printDsymPaths     print each symbol owner's dsym path
	-printMergedSymbols print info on each symbol before it is merged
	-printSummary       print summary of each targets contents
	-filterSegment      print only specific segment of each targets contents
	-filterSection      print only specific section of each targets contents
	-printHexContents   print the HEX content of each segment content
	-printVtables       print only vtable symbols, and their contents
	-noNListData        do not use nlist data for symbols/source infos
	-noDwarfData        do not use dwarf data for symbols/source infos
	-noDebugMapData     do not use debug map data for symbols/source infos
	-noDsymData         do not use dsym data for symbols/source infos
	-noFuncStartsData   do not use LC_FUNCTION_STARTS data for symbols
	-onlyNListData      only use nlist data for symbols/source infos
	-onlyDwarfData      only use dwarf data for symbols/source infos
	-onlyDebugMapData   only use debug map data for symbols/source infos
	-onlyDsymData       only use dsym data for symbols/source infos
	-onlyFuncStartsData only use LC_FUNCTION_STARTS data for symbols
	-originalBinary     path to the original kernel for a corefile, repeat for kexts
	-noDiskFaults       do not fault in symbol owners from disk
	-noTaskFaults       do not fault in symbol owners from tasks
	-noSelfDSCFaults    do not fault in from our dyld shared cache
	-noDiskDSCFaults    do not fault from the on disk dyld shared cache
	-safeMachVMReads    catch errors caused by missing backing pages
	-noPathRewriting    do not update B&I dsym source info paths
	-privateData        symbolicators do not share data in the SOD cache
	-noTRawSOD          do not allow TRaw style SOD when faulting
	-noMMapSOD          do not allow MMap style SOD when faulting
	-noDaemon           do not read/write from the storage daemon
	-noSourceInfoInSOD  do not include file name and line number data in SOD
	-noTextInSOD        do not include instruction data in SOD
	-failIfMissingDsym  exit with error code if any target does not have a dSYM
	-inlineFrames       print inlined functions instances 
	-fbs                store signatures as flatbuffers 
	-deferredDemangling do not perform eager symbol name demangling when faulting  table.\n- Ensures that any SQL/database problem is immediately visible and stops the deployment, so it can be fixed right away.\n- Makes the deployment process safer and more reliable for all environments, including CI/CD and shared hosting.\n\n## Testing\n- Seeder can be run multiple times without error.\n- If a SQL error occurs, it is logged and the deploy fails with a clear message.\n\n---\nThis is a critical fix for robust, production-grade Laravel deployments.